### PR TITLE
AUTH-1250: Build and release monitoring tool lambdas

### DIFF
--- a/.github/workflows/build-and-release-alerts.yml
+++ b/.github/workflows/build-and-release-alerts.yml
@@ -2,7 +2,7 @@ name: build-and-release-alerts-lambda
 on:
   push:
     branches:
-      - auth-1250-build-monitoring-tools
+      - main
     paths:
       - alerts-src/**
 

--- a/.github/workflows/build-and-release-alerts.yml
+++ b/.github/workflows/build-and-release-alerts.yml
@@ -1,0 +1,22 @@
+name: build-and-release-alerts-lambda
+on:
+  push:
+    branches:
+      - auth-1250-build-monitoring-tools
+    paths:
+      - alerts-src/**
+
+jobs:
+  build-and-release-alerts-lambda:
+    uses: ./.github/workflows/build-and-release.yml
+    with:
+      src-dir: alerts-src
+      zipname: alerts.zip
+    secrets:
+      AWS_DEPLOYER_ROLE: ${{ secrets.AWS_DEPLOYER_ROLE }}
+      SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
+      VERSIONED_ARTEFACT_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
+      SIGNED_ARTEFACT_DESTINATION_BUCKET: ${{ secrets.SIGNED_ARTEFACT_DESTINATION_BUCKET }}
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/build-and-release-heartbeat.yml
+++ b/.github/workflows/build-and-release-heartbeat.yml
@@ -1,0 +1,22 @@
+name: build-and-release-heartbeat-lambda
+on:
+  push:
+    branches:
+      - auth-1250-build-monitoring-tools
+    paths:
+      - heartbeat-src/**
+
+jobs:
+  build-and-release-heartbeat-lambda:
+    uses: ./.github/workflows/build-and-release.yml
+    with:
+      src-dir: heartbeat-src
+      zipname: heartbeat.zip
+    secrets:
+      AWS_DEPLOYER_ROLE: ${{ secrets.AWS_DEPLOYER_ROLE }}
+      SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}
+      VERSIONED_ARTEFACT_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
+      SIGNED_ARTEFACT_DESTINATION_BUCKET: ${{ secrets.SIGNED_ARTEFACT_DESTINATION_BUCKET }}
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/build-and-release-heartbeat.yml
+++ b/.github/workflows/build-and-release-heartbeat.yml
@@ -2,7 +2,7 @@ name: build-and-release-heartbeat-lambda
 on:
   push:
     branches:
-      - auth-1250-build-monitoring-tools
+      - main
     paths:
       - heartbeat-src/**
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,65 @@
+name: build-and-release-artefacts
+on:
+  push:
+    branches:
+      - auth-1250-build-monitoring-tools
+
+jobs:
+  build-alerts-lambda:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.13.0
+      - name: Install dependencies
+        working-directory: alerts-src
+        run: yarn install
+      - name: Build app
+        working-directory: alerts-src
+        run: yarn build
+      - name: Upload Alerts Lambda Artefact
+        uses: actions/upload-artifact@v3
+        with:
+          name: alerts.zip
+          path: dist/alerts.zip
+          retention-days: 5
+
+  release-alerts-lambda:
+    runs-on: ubuntu-latest
+    needs:
+      - build-alerts-lambda
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOYER_ROLE }}
+          role-session-name: github-actions-release-alerts-${{ github.run_id }}-${{ github.run_number }}
+          aws-region: eu-west-2
+      - name: Get alert lambda artefact
+        uses: actions/download-artifact@v3
+        with:
+          name: alerts.zip
+      - name: Copy alerts ZIP to S3
+        id: s3-source-artefact-copy
+        env:
+          SOURCE_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
+        run: |          
+          VERSION=$(aws s3api put-object --bucket "${SOURCE_BUCKET}" --key di-monitoring-utils/alerts.zip --body alerts.zip --output json --query 'VersionId')
+          echo "::set-output name=artefact-version::${VERSION}"
+      - name: Trigger AWS signer job
+        env:
+          SIGNING_PROFILE:  ${{ secrets.SIGNING_PROFILE }}
+          SOURCE_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
+          DESTINATION_BUCKET: ${{ secrets.SIGNED_ARTEFACT_DESTINATION_BUCKET }}
+          FILENAME: di-monitoring-utils/alerts.zip
+          VERSION: ${{ steps.s3-source-artefact-copy.outputs.artefact-version }}
+        run: |
+          aws signer start-signing-job \
+            --profile-name "${SIGNING_PROFILE}" \
+            --source "s3={bucketName=${SOURCE_BUCKET},key=${FILENAME},version=${VERSION}}" \
+            --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=signed-di-monitoring-utils-alerts-}"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -19,7 +19,7 @@ on:
         required: true
 
 jobs:
-  build-alerts-lambda:
+  build-lambda:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -44,10 +44,10 @@ jobs:
           path: dist/${{ inputs.zipname }}
           retention-days: 5
 
-  release-alerts-lambda:
+  release-lambda:
     runs-on: ubuntu-latest
     needs:
-      - build-alerts-lambda
+      - build-lambda
     permissions:
       id-token: write
       contents: read
@@ -56,15 +56,15 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOYER_ROLE }}
-          role-session-name: github-actions-release-alerts-${{ github.run_id }}-${{ github.run_number }}
+          role-session-name: github-actions-release-lambda-${{ github.run_id }}-${{ github.run_number }}
           aws-region: eu-west-2
 
-      - name: Get alert lambda artefact
+      - name: Get lambda artefact
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.zipname }}
 
-      - name: Copy alerts ZIP to S3
+      - name: Copy lambda ZIP to S3
         id: s3-source-artefact-copy
         env:
           SOURCE_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,29 +1,47 @@
 name: build-and-release-artefacts
 on:
-  push:
-    branches:
-      - auth-1250-build-monitoring-tools
+  workflow_call:
+    inputs:
+      src-dir:
+        required: true
+        type: string
+      zipname:
+        required: true
+        type: string
+    secrets:
+      AWS_DEPLOYER_ROLE:
+        required: true
+      SIGNING_PROFILE:
+        required: true
+      VERSIONED_ARTEFACT_BUCKET:
+        required: true
+      SIGNED_ARTEFACT_DESTINATION_BUCKET:
+        required: true
 
 jobs:
   build-alerts-lambda:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
           node-version: 16.13.0
+
       - name: Install dependencies
-        working-directory: alerts-src
-        run: yarn install
+        working-directory: ${{ inputs.src-dir }}
+        run: yarn install --prod
+
       - name: Build app
-        working-directory: alerts-src
+        working-directory: ${{ inputs.src-dir }}
         run: yarn build
-      - name: Upload Alerts Lambda Artefact
+
+      - name: Upload Lambda Artefact
         uses: actions/upload-artifact@v3
         with:
-          name: alerts.zip
-          path: dist/alerts.zip
+          name: ${{ inputs.zipname }}
+          path: dist/${{ inputs.zipname }}
           retention-days: 5
 
   release-alerts-lambda:
@@ -40,26 +58,32 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOYER_ROLE }}
           role-session-name: github-actions-release-alerts-${{ github.run_id }}-${{ github.run_number }}
           aws-region: eu-west-2
+
       - name: Get alert lambda artefact
         uses: actions/download-artifact@v3
         with:
-          name: alerts.zip
+          name: ${{ inputs.zipname }}
+
       - name: Copy alerts ZIP to S3
         id: s3-source-artefact-copy
         env:
           SOURCE_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
-        run: |          
-          VERSION=$(aws s3api put-object --bucket "${SOURCE_BUCKET}" --key di-monitoring-utils/alerts.zip --body alerts.zip --output json --query 'VersionId')
+          FILENAME: ${{ inputs.zipname }}
+          KEY: ${{ github.event.repository.name }}/${{ inputs.zipname }}
+        run: |
+          VERSION=$(aws s3api put-object --bucket "${SOURCE_BUCKET}" --key "${KEY}" --body "${FILENAME}" --output json --query 'VersionId')
           echo "::set-output name=artefact-version::${VERSION}"
+
       - name: Trigger AWS signer job
         env:
           SIGNING_PROFILE:  ${{ secrets.SIGNING_PROFILE }}
           SOURCE_BUCKET: ${{ secrets.VERSIONED_ARTEFACT_BUCKET }}
           DESTINATION_BUCKET: ${{ secrets.SIGNED_ARTEFACT_DESTINATION_BUCKET }}
-          FILENAME: di-monitoring-utils/alerts.zip
+          FILENAME: di-monitoring-utils/${{ inputs.zipname }}
           VERSION: ${{ steps.s3-source-artefact-copy.outputs.artefact-version }}
+          PREFIX: ${{ github.event.repository.name }}/${{ inputs.zipname }}/signed-
         run: |
           aws signer start-signing-job \
             --profile-name "${SIGNING_PROFILE}" \
             --source "s3={bucketName=${SOURCE_BUCKET},key=${FILENAME},version=${VERSION}}" \
-            --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=signed-di-monitoring-utils-alerts-}"
+            --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=${PREFIX}}"

--- a/alerts-src/package.json
+++ b/alerts-src/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "axios": "^0.26.0"
   },
+  "devDependencies": {
+    "aws-sdk": "^2.1090.0"
+  },
   "scripts": {
     "build": "mkdir -p ../dist && zip -r ../dist/alerts.zip ."
   }

--- a/alerts-src/yarn.lock
+++ b/alerts-src/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+aws-sdk@^2.1090.0:
+  version "2.1090.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1090.0.tgz#c30e4cbc177e4c3b7792020cc79dfaf155cc8197"
+  integrity sha512-oHdfbiuSjK9mn6rrm5fsitdwv7jEiYzaYB0Xz1kqjIczcVX3JEc+9ySdxlueQf4o5G3RVUcLRF2pIc5j9vcHSg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 axios@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
@@ -9,7 +24,92 @@ axios@^0.26.0:
   dependencies:
     follow-redirects "^1.14.8"
 
+base64-js@^1.0.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
+
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=

--- a/heartbeat-src/package.json
+++ b/heartbeat-src/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "cronitor": "^2.2.3"
   },
+  "devDependencies": {
+    "aws-sdk": "^2.1090.0"
+  },
   "scripts": {
     "build": "mkdir -p ../dist && zip -r ../dist/heartbeat.zip ."
   }

--- a/heartbeat-src/yarn.lock
+++ b/heartbeat-src/yarn.lock
@@ -9,12 +9,41 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aws-sdk@^2.1090.0:
+  version "2.1090.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1090.0.tgz#c30e4cbc177e4c3b7792020cc79dfaf155cc8197"
+  integrity sha512-oHdfbiuSjK9mn6rrm5fsitdwv7jEiYzaYB0Xz1kqjIczcVX3JEc+9ySdxlueQf4o5G3RVUcLRF2pIc5j9vcHSg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+base64-js@^1.0.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 cronitor@^2.2.3:
   version "2.2.3"
@@ -29,10 +58,35 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 follow-redirects@^1.14.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 js-yaml@^3.14.1:
   version "3.14.1"
@@ -42,7 +96,53 @@ js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=


### PR DESCRIPTION
## What?

- Add Github Actions workflows to build the lambda ZIP files
- Also push the ZIP file to S3 and trigger an AWS Signer job to produce signed code
- Add AWS SDK as dev dependency to both lambdas.

## Why?

This will ensure that the alerts and heartbeat lambda are built, signed and published to S3 where the deployment pipelines for both the DI auth smoke-tests and the DCS smoke tests can pick them up.

The AWS SDK dev dependency will improve the developer experience by enabling local testing and code completion in the IDE.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/206 (must be merged first)