### PR TITLE
AUTH-1250: Add semver style versioning to signed output

### DIFF
--- a/.github/workflows/build-and-release-alerts.yml
+++ b/.github/workflows/build-and-release-alerts.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       src-dir: alerts-src
       zipname: alerts.zip
+      version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
     secrets:
       AWS_DEPLOYER_ROLE: ${{ secrets.AWS_DEPLOYER_ROLE }}
       SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}

--- a/.github/workflows/build-and-release-heartbeat.yml
+++ b/.github/workflows/build-and-release-heartbeat.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       src-dir: heartbeat-src
       zipname: heartbeat.zip
+      version: ${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}
     secrets:
       AWS_DEPLOYER_ROLE: ${{ secrets.AWS_DEPLOYER_ROLE }}
       SIGNING_PROFILE: ${{ secrets.SIGNING_PROFILE }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,6 +8,9 @@ on:
       zipname:
         required: true
         type: string
+      version:
+        required: true
+        type: string
     secrets:
       AWS_DEPLOYER_ROLE:
         required: true
@@ -81,7 +84,7 @@ jobs:
           DESTINATION_BUCKET: ${{ secrets.SIGNED_ARTEFACT_DESTINATION_BUCKET }}
           FILENAME: di-monitoring-utils/${{ inputs.zipname }}
           VERSION: ${{ steps.s3-source-artefact-copy.outputs.artefact-version }}
-          PREFIX: ${{ github.event.repository.name }}/${{ inputs.zipname }}/signed-
+          PREFIX: ${{ github.event.repository.name }}/${{ inputs.zipname }}/signed-${{ inputs.version }}-
         run: |
           aws signer start-signing-job \
             --profile-name "${SIGNING_PROFILE}" \


### PR DESCRIPTION
## What?

- Use Github run numbers to simulate a semver style version number for the signed artefacts. 

## Why?

Concourse requires a numerical/sortable version identifier to correctly trigger, the generated signing job UUIDs are not working as required.

## Related PRs

#2 
