### PR TITLE
AUTH-1250: Refactor alerts to support DCS configuration

### DIFF
--- a/alerts-src/alerts.js
+++ b/alerts-src/alerts.js
@@ -1,35 +1,49 @@
 const axios = require('axios');
 const { getParameter } = require("./aws");
 
+const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
+    if(JSON.stringify(snsMessage).includes("ElastiCache")) {
+        return {
+            "attachments": [{
+                "fallback": Object.keys(snsMessage)[0] + "for cluster: " + Object.values(snsMessage)[0],
+                "color": "#ff9966",
+                "title": Object.values(snsMessage)[0] + "-notification",
+                "text": Object.keys(snsMessage)[0] + " for cluster: " + Object.values(snsMessage)[0],
+                "fields": [{
+                    "title": "Status",
+                    "value": "INFO",
+                    "short": false
+                }],
+                "footer": snsMessageFooter
+            }]
+        };
+    } else {
+        return {
+            "attachments": [{
+                "fallback": snsMessage.AlarmDescription,
+                "color": colorCode,
+                "title": snsMessage.AlarmName,
+                "text": snsMessage.AlarmDescription,
+                "fields": [{
+                    "title": "Status",
+                    "value": snsMessage.NewStateValue,
+                    "short": false
+                }],
+                "footer": snsMessageFooter
+            }]
+        };
+    }
+}
+
 const handler = async function(event, context) { // eslint-disable-line no-unused-vars
     console.log("Alert lambda triggered");
-    const slackHookUrl = await getParameter(process.env.DEPLOY_ENVIRONMENT+"-slack-hook-url");
-    var snsMessage = JSON.parse(event.Records[0].Sns.Message);
+    const slackHookUrl = process.env.SLACK_WEBHOOK_URL || await getParameter(process.env.DEPLOY_ENVIRONMENT+"-slack-hook-url");
+    let colorCode = process.env.ERROR_COLOR || "#C70039";
+    let snsMessageFooter = process.env.MESSAGE_FOOTER || "GOV.UK Sign In alert";
 
-    function formatMessage(snsMessage) {
-        if(JSON.stringify(snsMessage).includes("ElastiCache")) {
-            return {
-                "attachments": [{
-                    "fallback": Object.keys(snsMessage)[0] + "for cluster: " + Object.values(snsMessage)[0],
-                    "color": "#ff9966",
-                    "title": Object.values(snsMessage)[0] + "-notification",
-                    "text": Object.keys(snsMessage)[0] + " for cluster: " + Object.values(snsMessage)[0],
-                    "fields": [{"title": "Status","value": "INFO","short": false}],
-                    "footer": "GOV.UK Sign In alert"
-                }]
-            };
-        } else {
-            return {
-                "attachments": [{
-                    "fallback": snsMessage.AlarmDescription,
-                    "color": snsMessage.NewStateValue === "OK" ? "#36a64f" : "#C70039",
-                    "title": snsMessage.AlarmName,
-                    "text": snsMessage.AlarmDescription,
-                    "fields": [{"title": "Status", "value": snsMessage.NewStateValue, "short": false}],
-                    "footer": "GOV.UK Sign In alert"
-                }]
-            };
-        }
+    let snsMessage = JSON.parse(event.Records[0].Sns.Message);
+    if (snsMessage.NewStateValue === "OK") {
+        colorCode = process.env.OK_COLOR || "#36a64f";
     }
 
     var config = {
@@ -38,7 +52,7 @@ const handler = async function(event, context) { // eslint-disable-line no-unuse
         headers: {
             'Content-Type': 'application/json'
         },
-        data : JSON.stringify(formatMessage(snsMessage))
+        data : JSON.stringify(formatMessage(snsMessage, colorCode, snsMessageFooter))
     };
     console.log("Sending alert to slack");
     try {


### PR DESCRIPTION
## What?

- Merge in changes made to the DCS version of the Alerts lambda so that both Sign-in and DCS configuration can be supported
- Refactor `formatMessage()` function to take additional parameters defining colour and footer text

## Why?

The alerts lambda is also going to be used with the DCS smoke tests, the version currently used with the DCS was modified slightly to allow config via environment variables. This PR merges these modifications in making it suitable for both GOV.UK Sign in and DCS.
