### PR TITLE
AUT-830 - Include AWS account in Slack alert

### DIFF
--- a/alerts-src/alerts.js
+++ b/alerts-src/alerts.js
@@ -2,6 +2,11 @@ const axios = require('axios');
 const { getParameter } = require("./aws");
 
 const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
+    var description = snsMessage.AlarmDescription.split('ACCOUNT:');
+    var account = snsMessage.AWSAccountId
+    if (description.length > 1) {
+        account = description[1];
+    }
     if(JSON.stringify(snsMessage).includes("ElastiCache")) {
         return {
             "attachments": [{
@@ -9,26 +14,40 @@ const formatMessage = (snsMessage, colorCode, snsMessageFooter) => {
                 "color": "#ff9966",
                 "title": Object.values(snsMessage)[0] + "-notification",
                 "text": Object.keys(snsMessage)[0] + " for cluster: " + Object.values(snsMessage)[0],
-                "fields": [{
+                "fields": [
+                    {
                     "title": "Status",
                     "value": "INFO",
                     "short": false
-                }],
+                    },
+                    {
+                        "title": "Account",
+                        "value": account,
+                        "short": false
+                    }
+                ],
                 "footer": snsMessageFooter
             }]
         };
     } else {
         return {
             "attachments": [{
-                "fallback": snsMessage.AlarmDescription,
+                "fallback": description[0],
                 "color": colorCode,
                 "title": snsMessage.AlarmName,
-                "text": snsMessage.AlarmDescription,
-                "fields": [{
+                "text": description[0],
+                "fields": [
+                    {
                     "title": "Status",
                     "value": snsMessage.NewStateValue,
                     "short": false
-                }],
+                    },
+                    {
+                        "title": "Account",
+                        "value": account,
+                        "short": false
+                    }
+                ],
                 "footer": snsMessageFooter
             }]
         };


### PR DESCRIPTION
## What?

- If the cloudWatch alarm description contains `ACCOUNT:` then we can assume that this will be the account alias and therefore we will add this to the alert as a separate field.
- If the cloudWatch alarm description does not contain `ACCOUNT:` then we will just use the AWS account ID provided by the SNS payload.

## Why?

- This will help those actioning these alerts to quickly identify which AWS account the alert is coming from.
