### PR TITLE
Move aws-sdk to dependencies

### DIFF
--- a/slack-src/package.json
+++ b/slack-src/package.json
@@ -4,10 +4,10 @@
   "main": "slack.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.26.1"
+    "axios": "^0.26.1",
+    "aws-sdk": "^2.1099.0"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1099.0",
     "eslint": "^7.30.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
## What?

Move aws-sdk to dependencies

## Why?

NodeJS 18 Lambda no longer bundles aws-sdk v2
