### PR TITLE
BAU - Add slack-src to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,16 @@ updates:
         versions: ["17.x","18.x"]
     commit-message:
       prefix: BAU
+  - package-ecosystem: 'npm'
+    directory: '/slack-src'
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+      - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x","18.x"]
+    commit-message:
+      prefix: BAU


### PR DESCRIPTION
## What?

- Add slack-src to dependabot

## Why?

- So we are alerted to the latest dependency upgrades
